### PR TITLE
src/mmap.cxx: Fix GCC 13 compatibility

### DIFF
--- a/src/mmap.cxx
+++ b/src/mmap.cxx
@@ -12,6 +12,7 @@ LCDMapHandle = CreateFileMapping(LCDhandle, 0, PAGE_READWRITE, 0, 0, NULL);
 LCDptr = (int *)MapViewOfFile(LCDMapHandle, PAGE_ALL_ACCESS, 0, 0, 0); 
 */
 
+#include <cstdint>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Must include `cstdint` for `SIZE_MAX` macro.

```
../src/mmap.cxx: In member function 'UCHR* MMAP::map(int, int, off_t, off_t, mapping_access)':
../src/mmap.cxx:29:19: error: 'SIZE_MAX' was not declared in this scope
   29 | # define MMAP_MAX SIZE_MAX/4L
      |                   ^~~~~~~~
../src/mmap.cxx:265:31: note: in expansion of macro 'MMAP_MAX'
  265 |              ((end-start) > ( MMAP_MAX - PAGESIZE)) ||
      |                               ^~~~~~~~
../src/mmap.cxx:24:1: note: 'SIZE_MAX' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   23 | #include "mmap.hxx"
  +++ |+#include <cstdint>
   24 | #include <errno.h>
```